### PR TITLE
fix italics in drop-down formula

### DIFF
--- a/content/graph-theory/content.md
+++ b/content/graph-theory/content.md
@@ -371,7 +371,7 @@ layout are called __bipartite graphs__.
 :::
 
 {.reveal(when="blank-0 blank-1")} The bipartite graph with two sets of size _x_
-and _y_ is often written as `K_"x,y"`. It has [[_x_ × _y_|_x_ + _y_|2_x_ – _y_]]
+and _y_ is often written as `K_"x,y"`. It has [[_x_ × _y_|_x_ + _y_|2*x* – _y_]]
 edges, _{span.reveal(when="blank-2")}which means that in the above example there
 are ${m} × ${f} = ${m×f} dates._
 


### PR DESCRIPTION
Hi, and thank you for building such a great platform. Society really needs this!

I found a small bug/typo [here ](https://mathigon.org/course/graph-theory/handshakes) where markdown syntax was not rendered because inline italic syntax was needed.

Before:
![image](https://user-images.githubusercontent.com/461133/75627439-6ab82680-5bd0-11ea-91aa-d2f87e59724c.png)


After:
![image](https://user-images.githubusercontent.com/461133/75627395-0b5a1680-5bd0-11ea-9838-ce76d1b68072.png)
