### PR TITLE
Fix links which are not local on mathigon.io website

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,12 +1,12 @@
 # Translations and Localisation
 
-All of Mathigon's content is stored in this GitHub repository. The text, including translations, are written in [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet), a special way of annotating HTML. We use a slightly different [custom syntax](markdown.md), and you can have a look at one of our existing courses like [Circles and Pi](https://raw.githubusercontent.com/mathigon/textbooks/master/content/circles-and-pi/content.md).
+All of Mathigon's content is stored in this GitHub repository. The text, including translations, are written in [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet), a special way of annotating HTML. We use a slightly different [custom syntax](https://github.com/mathigon/textbooks/blob/master/docs/markdown.md), and you can have a look at one of our existing courses like [Circles and Pi](https://raw.githubusercontent.com/mathigon/textbooks/master/content/circles/content.md).
 
 Translations are powered by [GitLocalize](https://gitlocalize.com/repo/5711). In order to help us translate content, you have to create a GitHub account and then [contact us](mailto:contact@mathigon.org) to be added to the list of editors. [This blog post](https://blog.gitlocalize.com/posts/introducing-gitlocalize.html) explains how you can use the GitLocalize platform to add new languages, translate new courses, or fix bugs in existing translations.
 
 ## Automated Translations
 
-It is possible to generate automated translations using Google Translate, while preserving all built-in tags, markup and syntax. Simply edit the constants at the beginning of [utilities/translate.js](../utilities/translate.js), including a link to a Google Cloud Service Account for the Translate API) and then run `node utilities/translate.js`.
+It is possible to generate automated translations using Google Translate, while preserving all built-in tags, markup and syntax. Simply edit the constants at the beginning of [utilities/translate.js](https://github.com/mathigon/textbooks/blob/master/utilities/translate.js), including a link to a Google Cloud Service Account for the Translate API) and then run `node utilities/translate.js`.
 
 The auto-generated files will need to be reviewed manually, paying particular attention to these common issues:
 
@@ -21,6 +21,6 @@ Every course lives in a different folder under [content/](https://github.com/mat
 
 To translate a course, you have to take the `content.md` and `hints.yaml` files in a course folder, and copy them to the corresponding translations folder. Next, replace all the English text with the corresponding translation (but not any IDs, class names or embedded HTML code). Of course, you can start with just some sections, rather than the entire course at once.
 
-When adding a new language for the first time, you also have to add it to the [Gulpfile](https://github.com/mathigon/textbooks/blob/master/gulpfile.js#L19), to ensure it is parsed correctly, and create translated versions of the `*.yaml` files in the [shared/](https://github.com/mathigon/textbooks/tree/master/content/shared) directory (e.g. `bios.yaml` and `glossary.yaml`).
+When adding a new language for the first time, you also have to add it to the [Gulpfile](https://github.com/mathigon/textbooks/blob/master/gulpfile.js#L21), to ensure it is parsed correctly, and create translated versions of the `*.yaml` files in the [shared/](https://github.com/mathigon/textbooks/tree/master/content/shared) directory (e.g. `bios.yaml` and `glossary.yaml`).
 
-If you're familiar with GitHub and NodeJS, you can follow [these instructions](setup.md) to run a local webserver and test your changes. Otherwise, you can also just email the translations as a text file to dev@mathigon.org.
+If you're familiar with GitHub and NodeJS, you can follow [these instructions](https://github.com/mathigon/textbooks/blob/master/docs/setup.md) to run a local webserver and test your changes. Otherwise, you can also just email the translations as a text file to dev@mathigon.org.


### PR DESCRIPTION
Also fix the URL for course "Circles and Pi" and the sloc for language
addition in gulpfile.js